### PR TITLE
Turn psHandler and Modeller to daemons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /venv
 **/__pycache__
 data
+log

--- a/paths.py
+++ b/paths.py
@@ -5,3 +5,10 @@ APP_PROF_DATA_DIR_PATH = ROOT_PATH / "data"
 APP_PROF_DATA_DIR_PATH.mkdir(parents=True, exist_ok=True)
 APP_PROF_DATA_FILE_PATH = APP_PROF_DATA_DIR_PATH / "app_profiles.csv"
 SAMPLE_APP_PROF_DATA_PATH = ROOT_PATH / "src/tests/sample_data/sample_app_profile_data.csv"
+LOGGER_TEST_DIR_PATH = ROOT_PATH / "log"
+LOGGER_TEST_DIR_PATH.mkdir(parents=True, exist_ok=True)
+
+WADES_DIR_PATH = pathlib.Path.home() / ".wades"
+WADES_DIR_PATH.mkdir(parents=True, exist_ok=True)
+LOGGER_DIR_PATH = WADES_DIR_PATH / "log"
+LOGGER_DIR_PATH.mkdir(parents=True, exist_ok=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pytest>=6.1.2
 idna>=2.8
 numpy>=1.19.5
 pandas>=1.2.1
+python-daemon>=2.2.4

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ setup(
     install_requires=[
         'psutil',
         'pytest',
-        'idna'
+        'idna',
+        'python-daemon'
     ]
 )

--- a/src/main/common/Daemon.py
+++ b/src/main/common/Daemon.py
@@ -1,0 +1,70 @@
+import logging
+from typing import Union
+
+import psutil
+from daemon import DaemonContext, pidfile
+
+from paths import WADES_DIR_PATH
+from src.utils.error_messages import method_not_implemented_error_message
+from wades_config import pid_file_extension
+
+
+class Daemon:
+    def __init__(self, logger: logging.Logger, daemon_name: str) -> None:
+        """
+        Initializes the class using a logger and daemon name.
+        :param logger: The logger used to record the required information.
+        :type logger: logging
+        :param daemon_name: The name of the daemon.
+        :type daemon_name: str
+        """
+        file_name = daemon_name if daemon_name.endswith(pid_file_extension) else daemon_name + pid_file_extension
+        self.__file_path = WADES_DIR_PATH / file_name
+        self.__logger = logger
+        self.__daemon_name = daemon_name
+
+    def run(self) -> None:
+        """
+        Abstract method.
+        """
+        raise NotImplementedError(method_not_implemented_error_message.format("src.main.common.Daemon.Daemon.run"))
+
+    def terminate(self) -> None:
+        """
+        Terminates the running daemon.
+        """
+        pid = self.__get_pid()
+        try:
+            daemon_process = psutil.Process(pid)
+            daemon_process.terminate()
+        except psutil.NoSuchProcess:
+            self.__logger.info("Daemon with pid {} could not killed as it was not found.".format(pid))
+
+    def __get_pid(self) -> Union[int, None]:
+        """
+        Retrieves the PID from the PID file.
+        :return: the PID of the daemon, None otherwise.
+        :rtype: Union[int, None]
+        """
+        try:
+            with open(self.__file_path, 'r') as file:
+
+                pid = int(file.read().strip())
+                return pid
+
+        except (ValueError, FileNotFoundError, IOError):
+            return None
+
+    def start(self) -> None:
+        """
+        Starts the daemon.
+        """
+        if not self.__get_pid():
+            self.__logger.info("Starting Daemon {}".format(self.__daemon_name))
+            paths_to_preserve = [handler.baseFilename for handler in self.__logger.handlers
+                                 if isinstance(handler, logging.FileHandler)]
+
+            with DaemonContext(pidfile=pidfile.PIDLockFile(self.__file_path),
+                               working_directory=WADES_DIR_PATH,
+                               files_preserve=paths_to_preserve):
+                self.run()

--- a/src/main/common/LoggerUtils.py
+++ b/src/main/common/LoggerUtils.py
@@ -1,0 +1,43 @@
+import logging
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+
+from src.utils.error_messages import expected_type_but_received_message
+from wades_config import logging_level, log_file_max_size_bytes, max_number_rotating_log_files
+
+
+class LoggerUtils:
+
+    @staticmethod
+    def setup_logger(logger_name: str, log_file: Path) -> None:
+        """
+        Sets up a logger with the provided name and log output. The level is set in 'wades_config.py'
+        :raises TypeError if logger_name is not of type 'str', or if log_file i not of type 'pathlib.Path'.
+        :param logger_name: The name of the new logger. It should be the class name.
+        :type logger_name: str
+        :param log_file: The file where the logs should be outputted.
+        :type log_file: pathlib.Path
+        """
+
+        if not isinstance(logger_name, str):
+            raise TypeError(expected_type_but_received_message.format("logger_name", "str", logger_name))
+        if not isinstance(log_file, Path):
+            raise TypeError(expected_type_but_received_message.format("log_file", "pathlib.Path", log_file))
+
+        if not log_file.parent.exists():
+            log_file.mkdir(parents=True, exist_ok=True)
+        logger = logging.getLogger(logger_name)
+        formatter = logging.Formatter('%(asctime)s : %(message)s')
+        file_handler = RotatingFileHandler(filename=log_file,
+                                           mode='a+',
+                                           maxBytes=log_file_max_size_bytes,
+                                           backupCount=max_number_rotating_log_files
+                                           )
+
+        file_handler.setFormatter(formatter)
+        stream_handler = logging.StreamHandler()
+        stream_handler.setFormatter(formatter)
+
+        logger.setLevel(logging_level)
+        logger.addHandler(file_handler)
+        logger.addHandler(stream_handler)

--- a/src/main/main.py
+++ b/src/main/main.py
@@ -1,31 +1,26 @@
-from pprint import pprint
+import threading
 from time import sleep
 
-import psutil
-
-from src.main.psHandler.AppProfileDataManager import AppProfileDataManager
+from src.main.modeller.Modeller import Modeller
 from src.main.psHandler.ProcessHandler import ProcessHandler
 
-process_handler = ProcessHandler()
+if __name__ == "__main__":
 
+    modeller = Modeller()
+    ps_handler = ProcessHandler()
+    exit_program = False
+    while not exit_program:
+        user_input = str(input("command: "))
 
-def process_handler_run():
-    process_handler.collect_running_processes_information()
-    app_profiles = process_handler.get_registered_app_profiles_as_dict()
-    pprint(app_profiles)
-    return process_handler.get_registered_app_profiles_list()
-
-
-def connect_to_db():
-    app_db_manager = AppProfileDataManager()
-
-
-def app_profile_json():
-    app_profiles = process_handler_run()
-    AppProfileDataManager.save_app_profiles(app_profiles=app_profiles)
-
-
-for i in range(0, 10):
-    app_profile_json()
-ls = AppProfileDataManager.get_saved_profiles_as_dict()
-pprint(ls)
+        if user_input == "modeller start":
+            modeller.start()
+        elif user_input == "pshandler start":
+            ps_handler.start()
+        elif user_input == "pshandler terminate":
+            ps_handler.terminate()
+        elif user_input == "modeller terminate":
+            modeller.terminate()
+        elif user_input == "exit":
+            exit_program = True
+        else:
+            continue

--- a/src/main/modeller/Modeller.py
+++ b/src/main/modeller/Modeller.py
@@ -1,0 +1,60 @@
+import copy
+import logging
+from typing import List
+
+from paths import LOGGER_DIR_PATH, LOGGER_TEST_DIR_PATH
+from src.main.common.AppProfile import AppProfile
+from src.main.common.AppSummary import AppSummary
+from src.main.common.Daemon import Daemon
+from src.main.common.LoggerUtils import LoggerUtils
+from src.main.modeller.FrequencyTechnique import FrequencyTechnique
+from src.main.psHandler.AppProfileDataManager import AppProfileDataManager
+from wades_config import log_file_extension
+
+
+class Modeller(Daemon):
+
+    def __init__(self, logger_name: str = "Modeller", is_test: bool = False) -> None:
+        """
+        Abstracts the daemon that models the collected process information.
+        :param logger_name: The name of the logger.
+        :type logger_name: str
+        :param is_test: Flag for checking if this is called by a test. It changes the log path according to the value.
+        :type is_test: bool
+        """
+        logger_base_dir = LOGGER_DIR_PATH if not is_test else LOGGER_TEST_DIR_PATH
+        LoggerUtils.setup_logger(logger_name, logger_base_dir / (logger_name + log_file_extension))
+        self.__logger = logging.getLogger(logger_name)
+        self.__modelled_applications = list()
+        super(Modeller, self).__init__(self.__logger, logger_name)
+
+    @staticmethod
+    def model_application_profiles(application_profiles: List[AppProfile]) -> List[AppSummary]:
+        """
+        Create the frequency model for a list of AppProfiles. This is the main method of this class.
+        :param application_profiles: the application profiles to model.
+        :type application_profiles: List[AppProfile]
+        :return: the model of the provided application profiles.
+        :rtype List[AppSummary]
+        """
+        frequency_technique = FrequencyTechnique()
+
+        return frequency_technique(application_profiles)
+
+    def run(self) -> None:
+        """
+        Starts the modeller as a daemon. This method overrides the method in the parent class.
+        """
+        while True:
+            application_profiles = AppProfileDataManager.get_saved_profiles()
+            self.__logger.info("Starting to model {} application profiles.".format(len(application_profiles)))
+            Modeller.model_application_profiles(application_profiles)
+            self.__logger.info("Finished modelling {} application profiles.".format(len(application_profiles)))
+
+    def get_modelled_applications(self) -> List[AppSummary]:
+        """
+        Gets the modelled applications.
+        :return: The modelled applications.
+        :rtype: List[AppSummary]
+        """
+        return copy.deepcopy(self.__modelled_applications)

--- a/src/tests/test_app_profile.py
+++ b/src/tests/test_app_profile.py
@@ -31,6 +31,8 @@ Input validation test:
 
 """
 
+logger_name = "testAppProfile"
+
 
 def test_application_equality() -> None:
     """
@@ -250,7 +252,8 @@ def test_dict_format() -> None:
     """
     Test dict_format() for an application profile. It checks that the returned value is in the right format.
     """
-    process_handler = ProcessHandler()
+
+    process_handler = ProcessHandler(logger_name, True)
     process_handler.collect_running_processes_information()
     registered_applications = process_handler.get_registered_app_profiles_list()
     for registered_app in registered_applications:

--- a/src/tests/test_app_profile_data_manager.py
+++ b/src/tests/test_app_profile_data_manager.py
@@ -22,6 +22,7 @@ Input Validation tests:
 * get_saved_profiles_as_dict()
 """
 
+logger_name = "testAppProfileDataManager"
 
 # noinspection PyTypeChecker
 def test_save_app_profiles_with_input_validation() -> None:
@@ -60,7 +61,7 @@ def test_save_and_get_profile_data() -> None:
     """
     file_path_to_use = APP_PROF_DATA_DIR_PATH.absolute() / "app_data_manager_test.csv"
 
-    process_handler = ProcessHandler()
+    process_handler = ProcessHandler(logger_name, True)
     process_handler.collect_running_processes_information()
     actual_app_profiles = process_handler.get_registered_app_profiles_list()
 

--- a/src/tests/test_frequency_technique.py
+++ b/src/tests/test_frequency_technique.py
@@ -126,7 +126,7 @@ def test_execute_frequency_modelling_with_anomalies(saved_test_app_profiles_dict
     """
     app_profiles = build_application_profile_list(app_profiles_dict=saved_test_app_profiles_dict,
                                                   application_names={modelling_test_scenario.app_name})
-    fq = FrequencyTechnique()
+    fq = FrequencyTechnique(is_test=True)
     app_summaries = fq(data=app_profiles)
 
     assert len(app_summaries) == 1

--- a/src/tests/test_process_handler.py
+++ b/src/tests/test_process_handler.py
@@ -13,13 +13,15 @@ Output Format test:
 
 """
 
+logger_name = "testProcessHandler"
+
 
 def test_collect_running_processes_information() -> None:
     """
     Test collecting running process information by checking that it sets the value to the registered application
     properties.
     """
-    process_handler = ProcessHandler()
+    process_handler = ProcessHandler(logger_name, True)
     registered_apps_before_collection = process_handler.get_registered_application_names()
     assert len(registered_apps_before_collection) == 0
     process_handler.collect_running_processes_information()

--- a/src/utils/error_messages.py
+++ b/src/utils/error_messages.py
@@ -6,3 +6,4 @@ anomaly_range_percent_not_in_range = "Minimum number of points in a bin to not b
                                      "larger than {}, but value provided is {} "
 empty_collection_message = "Empty collection: {}"
 file_support_type_error_message = "Only files with extension {} are supported. Received {}"
+method_not_implemented_error_message = "Method {} has not been implemented."

--- a/wades_config.py
+++ b/wades_config.py
@@ -1,4 +1,14 @@
+import logging
+
 datetime_format = "%Y-%m-d %H:%M:%S:%f"
 prohibited_files = {"/etc/passwd", "/etc/shadow", "/etc/bashrc"}
 anomaly_detected_message = "Anomalies found."
 app_profile_retrieval_chunk_size = 10 ** 6
+minimum_retrieval_size_for_modelling = 10
+retrieval_periodicity = 3 * 60
+max_retrieval_periodicity_sec = 60 * 60  # One hour
+logging_level = logging.INFO
+log_file_extension = ".log"
+pid_file_extension = ".pid"
+log_file_max_size_bytes = 5 * 1024 * 1024
+max_number_rotating_log_files = 10


### PR DESCRIPTION
Closes #23.
Turn psHandler and Modeller to daemons to collect required information in the background.
Added a Daemon base class.
Added simple main class to interact with the daemons.
Added LoggerUtils to setup and retrieve a logger object.