### PR TITLE
Modified requirements for modelling data.

### DIFF
--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -3,6 +3,7 @@ from typing import Dict
 
 import pytest
 
+import wades_config
 from paths import SAMPLE_APP_PROF_DATA_PATH, LOGGER_TEST_DIR_PATH, TEST_APP_PROF_DATA_DIR_PATH
 from src.main.psHandler.AppProfileDataManager import AppProfileDataManager
 from src.utils.error_messages import empty_collection_message
@@ -29,6 +30,21 @@ def remove_all_create_files() -> None:
     Cleans up all the directories created for testing.
     """
     yield
-    directories_to_remove =[LOGGER_TEST_DIR_PATH, TEST_APP_PROF_DATA_DIR_PATH]
+    directories_to_remove = [LOGGER_TEST_DIR_PATH, TEST_APP_PROF_DATA_DIR_PATH]
     for directory_to_remove in directories_to_remove:
         shutil.rmtree(directory_to_remove)
+
+
+@pytest.fixture
+def setup_and_clean_up_modelling_requirements() -> None:
+    """
+    Sets up and cleans up the modelling requirements by changing the is_modelling value to true and minimum modelling
+    size to 3.
+    """
+    is_modelling = wades_config.is_modelling
+    wades_config.is_modelling = True
+    minimum_retrieval_size_for_modelling = wades_config.minimum_retrieval_size_for_modelling
+    wades_config.minimum_retrieval_size_for_modelling = 3
+    yield
+    wades_config.is_modelling = is_modelling
+    wades_config.minimum_retrieval_size_for_modelling = minimum_retrieval_size_for_modelling

--- a/src/tests/test_app_profile_data_manager.py
+++ b/src/tests/test_app_profile_data_manager.py
@@ -156,7 +156,7 @@ def test_save_and_get_abnormal_apps_from_file() -> None:
     Test saving and getting abnormal apps from a file is in the correct format and has the right values.
     """
     saved_app_profile = AppProfileDataManager.get_saved_profiles(paths.SAMPLE_APP_PROF_DATA_PATH)
-    ft = FrequencyTechnique(is_test=True)
+    ft = FrequencyTechnique()
     modelled_apps = ft(saved_app_profile)
     # Note: Some of the saved app profiles are not anomalous, however this test verifies that they are saved in correct
     # format.

--- a/src/tests/test_frequency_technique.py
+++ b/src/tests/test_frequency_technique.py
@@ -3,6 +3,7 @@ from typing import Dict
 
 import pytest
 
+import wades_config
 from src.main.common.enum.AppProfileAttribute import AppProfileAttribute
 from src.main.common.enum.AppSummaryAttribute import AppSummaryAttribute
 from src.main.common.enum.RiskLevel import RiskLevel
@@ -130,6 +131,7 @@ def test_execute_frequency_modelling_with_invalid_inputs() -> None:
                                                       True)
                          ]
                          )
+@pytest.mark.usefixtures('setup_and_clean_up_modelling_requirements')
 def test_execute_frequency_modelling_with_anomalies(saved_test_app_profiles_dict: Dict[str, dict],
                                                     modelling_test_scenario: AppModellingTestScenario) -> None:
     """
@@ -141,7 +143,7 @@ def test_execute_frequency_modelling_with_anomalies(saved_test_app_profiles_dict
     """
     app_profiles = build_application_profile_list(app_profiles_dict=saved_test_app_profiles_dict,
                                                   application_names={modelling_test_scenario.app_name})
-    fq = FrequencyTechnique(is_test=True)
+    fq = FrequencyTechnique()
     app_summaries = fq(data=app_profiles)
 
     assert len(app_summaries) == 1

--- a/wades_config.py
+++ b/wades_config.py
@@ -6,6 +6,7 @@ prohibited_files = {"/etc/passwd", "/etc/shadow", "/etc/bashrc", "/etc/profile",
 anomaly_detected_message = "Anomalies found."
 app_profile_retrieval_chunk_size = 10 ** 6
 minimum_retrieval_size_for_modelling = 10
+is_modelling = True
 retrieval_periodicity_sec = 1.5 * 60
 max_retrieval_periodicity_sec = 60 * 60  # One hour
 logging_level = logging.INFO


### PR DESCRIPTION
Closes #67.
Modified requirements for modelling data. It should only model the data if wades_config.is_modelling set to True and the number of data for each attribute in an application profile is larger or equal to the minimum.
Modified tests by adding a pytest.fixture.